### PR TITLE
feat: Added `ignore` parameter

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -20,6 +20,14 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Run Python Script
+      - name: Run 1
         shell: bash
         run: python3 check_headers.py .
+
+      - name: Run 2
+        shell: bash
+        run: python3 check_headers.py LICENSE README.md
+
+      - name: Run 3
+        shell: bash
+        run: python3 check_headers.py .github/** --ignore "LICENSE action.yaml"

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,11 @@ inputs:
       entire repository).
     required: false
     default: '.'
+  ignore:
+    description: |
+      The path(s) that will be ignored by the tool. These could be either individual
+      files, or directories, or glob patterns.
+    required: false
 
 runs:
   using: "composite"
@@ -20,4 +25,7 @@ runs:
 
     - name: Run check_headers script
       shell: bash
-      run: python3 ${{ github.action_path }}/check_headers.py ${{ inputs.paths }}
+      run: |
+        python3 ${{ github.action_path }}/check_headers.py \
+          ${{ inputs.paths }} \
+          --ignore "${{ inputs.ignore }}"

--- a/check_headers.py
+++ b/check_headers.py
@@ -619,7 +619,7 @@ class Source:
         return errors_found
 
 
-def analyze(paths: list[str], ignore: str) -> int:
+def analyze(paths: list[str], ignore: str | None) -> int:
     all_sources: dict[str, Source] = {}
     for entry in paths:
         if os.path.isfile(entry):
@@ -643,22 +643,25 @@ def analyze(paths: list[str], ignore: str) -> int:
                 continue
             all_sources[file] = Source(file)
 
-    for entry in ignore.split():
-        if os.path.isfile(entry):
-            del all_sources[entry]
-            continue
-        elif os.path.isdir(entry):
-            if entry.endswith("/"):
-                entry = entry[:-1]
-            pattern = entry + "/**"
-        elif "*" in entry or "?" in entry or "[" in entry:
-            pattern = entry
-        else:
-            raise SystemExit(f"Unknown path `{entry}`")
+    if ignore:
+        for entry in ignore.split():
+            if os.path.isfile(entry):
+                if entry in all_sources:
+                    del all_sources[entry]
+                continue
+            elif os.path.isdir(entry):
+                if entry.endswith("/"):
+                    entry = entry[:-1]
+                pattern = entry + "/**"
+            elif "*" in entry or "?" in entry or "[" in entry:
+                pattern = entry
+            else:
+                raise FileNotFoundError(f"Unknown path `{entry}`")
 
-        files = glob.glob(pattern, recursive=True)
-        for file in files:
-            del all_sources[file]
+            files = glob.glob(pattern, recursive=True)
+            for file in files:
+                if file in all_sources:
+                    del all_sources[file]
 
     n_errors = 0
     for src in all_sources.values():
@@ -685,8 +688,8 @@ if __name__ == "__main__":
         help="Path to the directory with C/C++ source files",
     )
     parser.add_argument(
-        "ignore",
-        nargs=1,
+        "--ignore",
+        required=False,
         help="Path(s) that should be ignored by the checker",
     )
 

--- a/check_headers.py
+++ b/check_headers.py
@@ -619,7 +619,7 @@ class Source:
         return errors_found
 
 
-def analyze(paths: list[str]) -> int:
+def analyze(paths: list[str], ignore: str) -> int:
     all_sources: dict[str, Source] = {}
     for entry in paths:
         if os.path.isfile(entry):
@@ -642,6 +642,23 @@ def analyze(paths: list[str]) -> int:
             if ext.lower() not in all_extensions:
                 continue
             all_sources[file] = Source(file)
+
+    for entry in ignore.split():
+        if os.path.isfile(entry):
+            del all_sources[entry]
+            continue
+        elif os.path.isdir(entry):
+            if entry.endswith("/"):
+                entry = entry[:-1]
+            pattern = entry + "/**"
+        elif "*" in entry or "?" in entry or "[" in entry:
+            pattern = entry
+        else:
+            raise SystemExit(f"Unknown path `{entry}`")
+
+        files = glob.glob(pattern, recursive=True)
+        for file in files:
+            del all_sources[file]
 
     n_errors = 0
     for src in all_sources.values():
@@ -667,7 +684,12 @@ if __name__ == "__main__":
         metavar="PATH",
         help="Path to the directory with C/C++ source files",
     )
+    parser.add_argument(
+        "ignore",
+        nargs=1,
+        help="Path(s) that should be ignored by the checker",
+    )
 
     args = parser.parse_args()
-    ret = analyze(args.paths)
+    ret = analyze(args.paths, args.ignore)
     sys.exit(ret)


### PR DESCRIPTION
The `ignore` parameter allows specifying a path or a list of paths that should be ignored when collecting the list of files to check.